### PR TITLE
pbrpc: upgrade  grpc  v1.27+

### DIFF
--- a/pbrpc/contract_service.pb.go
+++ b/pbrpc/contract_service.pb.go
@@ -65,11 +65,11 @@ var fileDescriptor_e663a77702825514 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion4
+const _ = grpc.SupportPackageIsVersion6
 
 // NativeCodeClient is the client API for NativeCode service.
 //
@@ -80,10 +80,10 @@ type NativeCodeClient interface {
 }
 
 type nativeCodeClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewNativeCodeClient(cc *grpc.ClientConn) NativeCodeClient {
+func NewNativeCodeClient(cc grpc.ClientConnInterface) NativeCodeClient {
 	return &nativeCodeClient{cc}
 }
 
@@ -206,10 +206,10 @@ type SyscallClient interface {
 }
 
 type syscallClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewSyscallClient(cc *grpc.ClientConn) SyscallClient {
+func NewSyscallClient(cc grpc.ClientConnInterface) SyscallClient {
 	return &syscallClient{cc}
 }
 


### PR DESCRIPTION
## Description

grpc dependency declared  in go.mod  is v1.35, but  code generated by protoc-gen-go  is older than grpc v1.27 
see [GRPC release note](https://github.com/grpc/grpc-go/releases/tag/v1.27.0) for more details 

Fixes # (issue) 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
