### PR TITLE
bugfix: fix unmarshalling  error in award_manage.Allowance

### DIFF
--- a/example/award_manage/main.go
+++ b/example/award_manage/main.go
@@ -106,8 +106,8 @@ func (am *awardManage) Balance(ctx code.Context) code.Response {
 
 func (am *awardManage) Allowance(ctx code.Context) code.Response {
 	args := struct {
-		From string `json:"from,excludes=/"`
-		To   string `json:"to,excludes=/"`
+		From string `json:"from" validate:"excludes=/"`
+		To   string `json:"to" validate:"excludes=/"`
 	}{}
 	if err := code.Unmarshal(ctx.Args(), &args); err != nil {
 		return code.Error(err)

--- a/example/game_assets/main.go
+++ b/example/game_assets/main.go
@@ -20,7 +20,7 @@ const (
 
 type assetType struct {
 	TypeID   string `json:"type_id" validate:"required,excludes=/"`
-	TypeDesc string `json:"type_desc" validat:"required"`
+	TypeDesc string `json:"type_desc" validate:"required"`
 }
 
 type asset struct {

--- a/example/game_assets/main.go
+++ b/example/game_assets/main.go
@@ -20,7 +20,7 @@ const (
 
 type assetType struct {
 	TypeID   string `json:"type_id" validate:"required,excludes=/"`
-	TypeDesc string `json:"type_desc" validate:"required"`
+	TypeDesc string `json:"type_desc" validat:"required"`
 }
 
 type asset struct {


### PR DESCRIPTION
## Description
contract using go struct tag to unmarshal contract args, and   using validate tag to validate args, wrong tags cause unmarshal  error 

What is the purpose of the change?
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Brief of your solution

Please describe your solution to solve the issue or feature request.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
